### PR TITLE
Change Retry trait's 'futureRetry' function to log a warning rather t…

### DIFF
--- a/src/main/scala/com/gilt/gfc/kinesis/publisher/RawKinesisStreamPublisher.scala
+++ b/src/main/scala/com/gilt/gfc/kinesis/publisher/RawKinesisStreamPublisher.scala
@@ -122,7 +122,7 @@ private[publisher] trait Retry extends Loggable {
           Future.successful(success)
         }
         case failure@Failure(ex) if retryCount < config.allowedRetriesOnFailure => {
-          error(s"$desc failed, attempting retry in ${config.retryBackoffDuration}", ex)
+          warn(s"$desc failed, attempting retry in ${config.retryBackoffDuration}", ex)
 
           val retriedCount = retryCount + 1
           after(config.retryBackoffDuration) {


### PR DESCRIPTION
…han an error when proceeding with a retry.

The 'error' level is typically used to indicate something unexpected happened that may need attention.  In the case of a retry loop, these are built specifically for this purpose.  Since it is useful to know when retries are happening, perhaps a 'warning' level makes the most sense.